### PR TITLE
Add AGENTS.md files for AI coding assistants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# Soccer AI
+
+Object detection and tracking system for soccer videos using YOLO (ultralytics) + ByteTrack (supervision).
+
+## Tech Stack
+
+- **Python 3** with `ultralytics`, `roboflow`, `supervision`, `tqdm`, `pyyaml`
+- **YOLO** for object detection (YOLOv8/v11 models)
+- **ByteTrack** (via `supervision`) for multi-object tracking
+- **Roboflow** for dataset management
+
+## Classes (4 total)
+
+| ID | Class      |
+|----|------------|
+| 0  | ball       |
+| 1  | goalkeeper |
+| 2  | player     |
+| 3  | referee    |
+
+## Project Layout
+
+```
+soccer_ai/
+├── train.py              # Training entry point (replaces Kaggle notebook)
+├── inference.py           # Inference entry point (replaces Colab notebook)
+├── merge_datasets.py      # Dataset merging utility
+├── requirements.txt       # Dependencies
+└── src/
+    ├── data/
+    │   ├── dataset.py         # Download, fix YAML, remap labels
+    │   └── dataset_merger.py  # Merge ball-only + full datasets
+    ├── models/
+    │   └── trainer.py         # YOLO training wrapper
+    ├── inference/
+    │   └── video_processor.py # VideoProcessor class + AnnotatorConfig
+    └── utils/                 # (reserved for future utilities)
+```
+
+## Entry Points
+
+- `python train.py --help` — Train a model (downloads from Roboflow, remaps labels, trains)
+- `python inference.py --help` — Process a video with detection + tracking
+- `python merge_datasets.py --help` — Merge a ball-only dataset with the full 4-class dataset
+
+## Label Format
+
+YOLO format: `class_id center_x center_y width height` (normalized 0-1).
+
+Roboflow raw labels use different class IDs that get remapped during training:
+- 4 → 0 (ball), 6 → 1 (goalkeeper), 11 → 2 (player), 16 → 3 (referee)
+
+## Environments
+
+- **Training**: Kaggle (GPU) — upload project, `pip install -r requirements.txt`, run `train.py`
+- **Inference**: Colab or local — clone repo, install deps, run `inference.py`
+- **Development**: Local with Cursor or Claude Code
+
+## Conventions
+
+- Entry point scripts live in project root, all logic lives in `src/`
+- Use `argparse` for CLI arguments — no hardcoded paths or config values
+- JSON detection data is auto-exported alongside output videos (`*_detections.json`)
+- See `WORKFLOW_GUIDE.md` for full development and deployment workflows
+- See `DATASET_MIXING_GUIDE.md` for dataset merging strategies

--- a/src/data/AGENTS.md
+++ b/src/data/AGENTS.md
@@ -1,0 +1,43 @@
+# Data Module
+
+Handles dataset download, preprocessing, and merging.
+
+## Key Functions
+
+- `download_dataset()` — Downloads from Roboflow in YOLOv8 format
+- `fix_data_yaml()` — Overwrites `data.yaml` to enforce 4 classes: `[ball, goalkeeper, player, referee]`
+- `remap_labels()` — Remaps Roboflow class IDs to our 0-3 scheme. Removes labels not in the class map and deletes orphaned images
+- `merge_datasets()` — Merges a ball-only dataset with the full 4-class dataset, limiting ball-only ratio to prevent class imbalance
+
+## Class ID Mapping (Roboflow → Ours)
+
+```
+4  → 0  (ball)
+6  → 1  (goalkeeper)
+11 → 2  (player)
+16 → 3  (referee)
+```
+
+All other Roboflow classes are **dropped** (lines removed from label files).
+
+## Dataset Structure (YOLOv8)
+
+```
+dataset/
+├── data.yaml
+├── train/
+│   ├── images/   # .jpg files
+│   └── labels/   # .txt files (YOLO format)
+├── valid/         # Roboflow uses "valid", not "val"
+│   ├── images/
+│   └── labels/
+└── test/
+    ├── images/
+    └── labels/
+```
+
+## Gotchas
+
+- Roboflow names the validation split `valid/`, not `val/` — the code handles this
+- `remap_labels()` deletes label files (and their images) if no valid classes remain after remapping
+- When merging ball-only datasets: images with visible players but no player labels will teach the model to treat players as background — the `max_ball_only_ratio` parameter (default 0.3) mitigates this

--- a/src/inference/AGENTS.md
+++ b/src/inference/AGENTS.md
@@ -1,0 +1,30 @@
+# Inference Module
+
+Processes soccer videos with YOLO detection + ByteTrack tracking.
+
+## `VideoProcessor`
+
+Main class. Initialized with a YOLO model path, then call `process_video()`.
+
+### Processing Pipeline (per frame)
+
+1. Run YOLO inference → `sv.Detections`
+2. Separate ball detections (class 0) from others
+3. Pad ball bounding boxes by 10px (balls are small)
+4. Apply NMS to non-ball detections (class-agnostic)
+5. Subtract 1 from non-ball class IDs (so goalkeeper=0, player=1, referee=2 for the color palette)
+6. Update ByteTrack tracker with non-ball detections
+7. Annotate: ellipses for players/goalkeepers/referees, triangles for ball, labels with tracker IDs
+
+### Output
+
+- Annotated video (mp4)
+- Detection JSON (`*_detections.json`) — auto-generated alongside video, contains per-frame bounding boxes with tracker IDs and confidence scores
+
+## `AnnotatorConfig`
+
+Dataclass for annotation styling (colors, thickness, etc.). Defaults are sensible — only override for visual customization.
+
+## Gotcha
+
+Non-ball class IDs are shifted by -1 internally (`class_id -= 1`) for color palette indexing. This is intentional — the 3-color palette maps to goalkeeper/player/referee after the ball class is removed.

--- a/src/models/AGENTS.md
+++ b/src/models/AGENTS.md
@@ -1,0 +1,19 @@
+# Models Module
+
+Wraps `ultralytics` YOLO training.
+
+## `train_model()`
+
+Thin wrapper around `model.train()`. All YOLO training params are passed through.
+
+### Fine-Tuning Parameters
+
+- `freeze` — Number of layers to freeze (24 = entire backbone, only detection head trains)
+- `lr0` — Initial learning rate (use ~1e-4 for fine-tuning small datasets)
+- `lrf` — Final LR factor (final_lr = lr0 * lrf, e.g. 0.01)
+
+These are optional — omit them for standard training from scratch.
+
+### Output
+
+Results go to `{project}/{name}/` with `weights/best.pt` as the final model.


### PR DESCRIPTION
## Summary
- Adds `AGENTS.md` files (root + `src/data/`, `src/models/`, `src/inference/`) to provide structured context for AI coding tools
- Uses `AGENTS.md` instead of `CLAUDE.md` so both **Cursor** and **Claude Code** benefit from the same instructions
- Root file covers project overview, tech stack, classes, layout, and conventions; subdirectory files document module-specific details and gotchas

## Test plan
- [ ] Verify Cursor picks up the root `AGENTS.md` when opening the project
- [ ] Verify Claude Code loads subdirectory `AGENTS.md` files when working in `src/data/`, `src/models/`, or `src/inference/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)